### PR TITLE
feat: add PinpointEntry for infolist

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,48 @@ Pinpoint::make('location')
     ->searchable(false) // Hide search box
 ```
 
+### Infolist Entry (Read-Only Display)
+
+For displaying locations in infolists (view mode), use the `PinpointEntry` component. It displays a clean, read-only Google Map with a marker at the specified coordinates.
+
+```php
+use Fahiem\FilamentPinpoint\PinpointEntry;
+
+public static function infolist(Infolist $infolist): Infolist
+{
+    return $infolist
+        ->schema([
+            PinpointEntry::make('location')
+                ->label('Location')
+                ->latField('lat')
+                ->lngField('lng')
+                ->columnSpanFull(),
+        ]);
+}
+```
+
+#### Customization Options
+
+```php
+PinpointEntry::make('location')
+    ->label('Business Location')
+    ->defaultLocation(-6.200000, 106.816666) // Jakarta
+    ->defaultZoom(15)
+    ->height(400)
+    ->latField('lat')
+    ->lngField('lng')
+    ->columnSpanFull()
+```
+
+The `PinpointEntry` displays:
+- A read-only Google Map with a marker at the specified coordinates
+- No text or address information - just a clean map view
+- Full dark mode support
+
+
 ## Available Methods
+
+### Pinpoint (Form Field)
 
 | Method | Description | Default |
 |--------|-------------|---------|
@@ -142,6 +183,19 @@ Pinpoint::make('location')
 | `postalCodeField(string $field)` | Field name for auto-fill postal/zip code | `null` |
 | `draggable(bool $draggable)` | Enable/disable marker dragging | `true` |
 | `searchable(bool $searchable)` | Enable/disable search box | `true` |
+
+### PinpointEntry (Infolist Entry)
+
+| Method | Description | Default |
+|--------|-------------|---------|
+| `defaultLocation(float $lat, float $lng)` | Set default center location | `-0.5050, 117.1500` |
+| `defaultZoom(int $zoom)` | Set default zoom level | `13` |
+| `height(int $height)` | Set map height in pixels | `400` |
+| `latField(string $field)` | Field name for latitude | `'lat'` |
+| `lngField(string $field)` | Field name for longitude | `'lng'` |
+| `getLat()` | Get latitude from record | Returns field value or default |
+| `getLng()` | Get longitude from record | Returns field value or default |
+
 
 ## Getting a Google Maps API Key
 

--- a/resources/views/pinpoint-entry.blade.php
+++ b/resources/views/pinpoint-entry.blade.php
@@ -1,0 +1,129 @@
+{{--
+    Pinpoint Entry - Google Maps Location Display for Filament 4 Infolists
+
+    A read-only map display for infolists showing location with a marker.
+    Features: Static marker, no interaction, dark mode support.
+
+    @author Fahiem
+    @version 1.0.0
+    @package fahiem/filament-pinpoint
+--}}
+<x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
+    @php
+        $defaultLat = $getDefaultLat();
+        $defaultLng = $getDefaultLng();
+        $defaultZoom = $getDefaultZoom();
+        $height = $getHeight();
+        $lat = $getLat();
+        $lng = $getLng();
+        $apiKey = $getApiKey();
+    @endphp
+
+    <div x-data="{
+        map: null,
+        marker: null,
+        lat: parseFloat(@js($lat)) || @js($defaultLat),
+        lng: parseFloat(@js($lng)) || @js($defaultLng),
+        defaultZoom: @js($defaultZoom),
+        isMapLoaded: false,
+    
+        init() {
+            this.loadGoogleMaps();
+        },
+    
+        loadGoogleMaps() {
+            if (window.google && window.google.maps) {
+                this.initMap();
+                return;
+            }
+    
+            if (window.googleMapsLoading) {
+                window.googleMapsCallbacks = window.googleMapsCallbacks || [];
+                window.googleMapsCallbacks.push(() => this.initMap());
+                return;
+            }
+    
+            window.googleMapsLoading = true;
+            window.googleMapsCallbacks = [];
+    
+            const apiKey = '{{ $apiKey }}';
+            if (!apiKey) {
+                console.error('Google Maps API key is not configured. Please set GOOGLE_MAPS_API_KEY in your .env file.');
+                return;
+            }
+    
+            const script = document.createElement('script');
+            script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=googleMapsCallback`;
+            script.async = true;
+            script.defer = true;
+    
+            window.googleMapsCallback = () => {
+                window.googleMapsLoading = false;
+                this.initMap();
+                window.googleMapsCallbacks.forEach(cb => cb());
+                window.googleMapsCallbacks = [];
+            };
+    
+            document.head.appendChild(script);
+        },
+    
+        initMap() {
+            const mapElement = this.$refs.map;
+            if (!mapElement) return;
+    
+            this.map = new google.maps.Map(mapElement, {
+                center: { lat: this.lat, lng: this.lng },
+                zoom: this.defaultZoom,
+                mapTypeControl: false,
+                streetViewControl: false,
+                fullscreenControl: false,
+                zoomControl: true,
+                draggable: true,
+                scrollwheel: true,
+                disableDoubleClickZoom: false,
+                gestureHandling: 'auto'
+            });
+    
+            this.marker = new google.maps.Marker({
+                position: { lat: this.lat, lng: this.lng },
+                map: this.map,
+                draggable: false,
+                animation: google.maps.Animation.DROP,
+            });
+    
+            this.isMapLoaded = true;
+        }
+    }" x-init="init()" class="fi-in-pinpoint-entry">
+        {{-- Map Container --}}
+        <div class="relative rounded-lg overflow-hidden border border-gray-300 dark:border-gray-700">
+            <div x-ref="map" style="height: {{ $height }}px; width: 100%;" class="bg-gray-100 dark:bg-gray-800">
+                <div x-show="!isMapLoaded"
+                    style="display: flex; align-items: center; justify-content: center; height: 100%;">
+                    <div style="display: flex; align-items: center; gap: 8px;" class="text-gray-500 dark:text-gray-400">
+                        <svg style="animation: spin 1s linear infinite; width: 20px; height: 20px;"
+                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle style="opacity: 0.25;" cx="12" cy="12" r="10" stroke="currentColor"
+                                stroke-width="4"></circle>
+                            <path style="opacity: 0.75;" fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+                            </path>
+                        </svg>
+                        <span>{{ __('filament-pinpoint::pinpoint.loading_map') }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        @keyframes spin {
+            from {
+                transform: rotate(0deg);
+            }
+
+            to {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
+</x-dynamic-component>

--- a/src/PinpointEntry.php
+++ b/src/PinpointEntry.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Fahiem\FilamentPinpoint;
+
+use Closure;
+use Filament\Infolists\Components\Entry;
+
+/**
+ * PinpointEntry - Google Maps Location Display for Filament 4 Infolists
+ *
+ * A custom Filament infolist entry that displays a read-only Google Maps view
+ * with a marker showing the location from the record.
+ *
+ * Features:
+ * - Display location on Google Maps (read-only)
+ * - Show marker at specified coordinates
+ * - Dark mode support
+ *
+ * @author Fahiem
+ * @version 1.0.0
+ * @license MIT
+ */
+class PinpointEntry extends Entry
+{
+    protected string $view = 'filament-pinpoint::pinpoint-entry';
+
+    protected float|Closure $defaultLat = -0.5050;
+
+    protected float|Closure $defaultLng = 117.1500;
+
+    protected int|Closure $defaultZoom = 13;
+
+    protected int|Closure $height = 400;
+
+    protected string|Closure|null $latField = 'lat';
+
+    protected string|Closure|null $lngField = 'lng';
+
+    public function defaultLocation(float $lat, float $lng): static
+    {
+        $this->defaultLat = $lat;
+        $this->defaultLng = $lng;
+
+        return $this;
+    }
+
+    public function defaultZoom(int $zoom): static
+    {
+        $this->defaultZoom = $zoom;
+
+        return $this;
+    }
+
+    public function height(int $height): static
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    public function latField(string|Closure|null $field): static
+    {
+        $this->latField = $field;
+
+        return $this;
+    }
+
+    public function lngField(string|Closure|null $field): static
+    {
+        $this->lngField = $field;
+
+        return $this;
+    }
+
+    public function getDefaultLat(): float
+    {
+        return $this->evaluate($this->defaultLat) ?? config('filament-pinpoint.default.lat', -0.5050);
+    }
+
+    public function getDefaultLng(): float
+    {
+        return $this->evaluate($this->defaultLng) ?? config('filament-pinpoint.default.lng', 117.1500);
+    }
+
+    public function getDefaultZoom(): int
+    {
+        return $this->evaluate($this->defaultZoom) ?? config('filament-pinpoint.default.zoom', 13);
+    }
+
+    public function getHeight(): int
+    {
+        return $this->evaluate($this->height) ?? config('filament-pinpoint.default.height', 400);
+    }
+
+    public function getLatField(): ?string
+    {
+        return $this->evaluate($this->latField);
+    }
+
+    public function getLngField(): ?string
+    {
+        return $this->evaluate($this->lngField);
+    }
+
+    public function getLat(): ?float
+    {
+        $record = $this->getRecord();
+        $latField = $this->getLatField();
+        
+        if (!$record || !$latField) {
+            return $this->getDefaultLat();
+        }
+
+        return $record->{$latField} ?? $this->getDefaultLat();
+    }
+
+    public function getLng(): ?float
+    {
+        $record = $this->getRecord();
+        $lngField = $this->getLngField();
+        
+        if (!$record || !$lngField) {
+            return $this->getDefaultLng();
+        }
+
+        return $record->{$lngField} ?? $this->getDefaultLng();
+    }
+
+    public function getApiKey(): ?string
+    {
+        return config('filament-pinpoint.api_key');
+    }
+}
+


### PR DESCRIPTION
### Add `PinpointEntry` for Read-Only Map Display in Infolists

Introduces `PinpointEntry` component for displaying locations in Filament infolists (view mode).

### **What's Added**

* **`PinpointEntry` component:** Read-only Google Map display with marker for infolists

### **Why This is Useful**

* Completes CRUD support (forms + infolists)
* Consistent UX between editing and viewing locations
* Simple API matching `PinpointField`