### PR TITLE
feat: add locale support to Google Maps script in pinpoint views

### DIFF
--- a/resources/views/pinpoint-entry.blade.php
+++ b/resources/views/pinpoint-entry.blade.php
@@ -17,6 +17,7 @@
         $pins = $getPins();
         $hasPins = $hasPins();
         $fitBounds = $getFitBounds();
+        $locale = str_replace('_', '-', app()->getLocale());
     @endphp
 
     <div
@@ -71,7 +72,7 @@
                 }
 
                 const script = document.createElement('script');
-                script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=googleMapsCallback`;
+                script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=googleMapsCallback&language={{ str_replace('_', '-', app()->getLocale()) }}`;
                 script.async = true;
                 script.defer = true;
 

--- a/resources/views/pinpoint.blade.php
+++ b/resources/views/pinpoint.blade.php
@@ -31,6 +31,7 @@
         $postalCodeField = $getPostalCodeField();
         $countryField = $getCountryField();
         $apiKey = $getApiKey();
+        $locale = str_replace('_', '-', app()->getLocale());
 
         $state = $getState();
         $currentLat = $state['lat'] ?? $defaultLat;
@@ -138,7 +139,7 @@
                 }
 
                 const script = document.createElement('script');
-                script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=googleMapsCallback`;
+                script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=googleMapsCallback&language={{ $locale }}`;
                 script.async = true;
                 script.defer = true;
 


### PR DESCRIPTION
- Introduced locale variable to format the language parameter for Google Maps API script in both pinpoint and pinpoint-entry views.
- Ensured that the language setting reflects the application's current locale, enhancing internationalization support.